### PR TITLE
Used cleaned up word overlap in footer

### DIFF
--- a/src/app/footer.scss
+++ b/src/app/footer.scss
@@ -4,27 +4,29 @@ body>footer{
     dt:after{
         content: ":";
     }
-    dd{
+    dd:after{
         content: ";";
     }
 }
 
 body>footer{
-    font-size: $font-size-small;
-    height: 2em;
+    height: $space-size*2;
     padding-top: 0.25em;
     overflow: hidden;
-    white-space:nowrap;
     .container{
-        >*{
-            display: inline-block;
+        overflow: hidden;
+        padding-right: $sidebar-width;
+        &>nav{
+            position: absolute;
+            top: 0px;
+            right: 0px;
+            text-align: right;
+            height: 100%;
         }
     }
-    nav{
-        float: right;
-    }
-    nav    > a{
+    nav > a{
         padding: 0em;
+        padding: 0.25em;
     }
     dd, dt, dl{
         display: inline-block;


### PR DESCRIPTION
I absolute positioned the documentation nav link in the footer, and added padding so there is no overlap.

A layout problem is that server attribute labels are too long, so item attributes get lost. This PR doesn't fix that issue, and considering different layouts will change the number of characters per line there might not be a great solution.