### PR TITLE
Local i18n files

### DIFF
--- a/gulpfile.js/tasks/build.js
+++ b/gulpfile.js/tasks/build.js
@@ -7,7 +7,7 @@ gulp.task('build', function () {
 });
 
 gulp.task('build:app', function () {
-    gulpSequence('assets', 'fonts', 'images', 'partials', 'index.html', 'motech.css', 'motech.js:hint', 'motech.js:build')();
+    gulpSequence('assets', 'fonts', 'images', 'partials', 'index.html', 'motech.css', 'i18n', 'motech.js:hint', 'motech.js:build')();
 });
 
 gulp.task('build:styleguide', function() {

--- a/gulpfile.js/tasks/i18n-messages.js
+++ b/gulpfile.js/tasks/i18n-messages.js
@@ -1,0 +1,46 @@
+var config = require('../config');
+var gulp = require('gulp');
+var path = require('path');
+var concat = require('gulp-concat');
+var props = require('gulp-props');
+var gulpSequence = require('gulp-sequence');
+var jsoncombine = require("gulp-jsoncombine");
+var Finder = require('fs-finder');
+var jsesc = require('jsesc');
+
+var languageTypes = [];
+
+gulp.task('i18n', function(){
+	return gulpSequence('i18n-messages')();
+})
+
+gulp.task('i18n-messages', function (callback) {
+	languages = {}
+	var allFiles = Finder.from(config.app.src).findFiles('*.properties');
+	allFiles.forEach(function(filename){
+		langReg = new RegExp('\..\.properties$', 'gi');
+		matches = filename.match(langReg).forEach(function(match){
+			lang = match.replace('.properties','');
+			if(!languages[lang]){
+				languages[lang] = [];
+			}
+			languages[lang].push(filename)
+		});
+	});
+	langsNum = 0;
+	function checkDone(){
+		if(langsNum == Object.keys(languages).length){
+			callback();
+		}
+	}
+	Object.keys(languages).forEach(function(lang){
+		var stream = gulp.src(languages[lang])
+			.pipe(concat('motech-messages.'+lang+'.json'))
+			.pipe(props({namespace:'', space: 2}))
+			.pipe(gulp.dest(path.join(config.app.dest, 'i18n-messages')));
+		stream.on('end', function(){
+			langsNum++;
+			checkDone();
+		});
+	});
+});

--- a/gulpfile.js/tasks/motech.js.js
+++ b/gulpfile.js/tasks/motech.js.js
@@ -26,7 +26,7 @@ var paths = {
 }
 
 gulp.task('motech.js', function () {
-    gulpSequence('js:hint', 'js:build')();
+    gulpSequence('motech.js:hint', 'motech.js:build')();
 });
 
 // Static: Compress JS files into motech.js

--- a/gulpfile.js/tasks/test.js
+++ b/gulpfile.js/tasks/test.js
@@ -8,3 +8,10 @@ gulp.task('test', function(done) {
         singleRun: true
     }, done).start()
 });
+
+
+gulp.task('tdd', function (done) {
+  new Server({
+    configFile: '../../../karma.conf.js'
+  }, done).start();
+});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "phantomjs-prebuilt": "^2.1.7",
     "postcss": "^5.0.19",
     "postcss-flexibility": "^1.0.3",
+    "q": "^1.4.1",
     "require-dir": "~0.3.0",
     "sc5-styleguide": "^0.3.41",
     "yargs": "~3.31.0"
@@ -49,6 +50,8 @@
   "devDependencies": {
     "bower-files": "~3.11.3",
     "gulp-jshint": "^2.0.0",
+    "gulp-jsoncombine": "^1.0.3",
+    "gulp-props": "^1.2.0",
     "gulp-s3": "^0.3.0",
     "gulp-s3-deploy": "^1.0.1",
     "jshint": "^2.9.1"

--- a/src/app/app.routes.js
+++ b/src/app/app.routes.js
@@ -2,11 +2,21 @@
     'use strict';
 
     angular.module('motech-dashboard')
-        .config(dashboardRoutes);
+        .config(dashboardRoutes)
+        .run(onMotechRefresh);
 
     dashboardRoutes.$inject = ['$urlRouterProvider'];
     function dashboardRoutes($urlRouterProvider) {
         $urlRouterProvider.otherwise("/bundles");
+    }
+
+    onMotechRefresh.$inject = ['$rootScope', '$state'];
+    function onMotechRefresh($rootScope, $state){
+    	$rootScope.$on('motech.refresh', function(){
+            if($state.current && !$state.current.abstract){
+                $state.go($state.current, {}, {reload: true});                
+            }
+    	});
     }
 
 })();

--- a/src/app/state.service.js
+++ b/src/app/state.service.js
@@ -4,14 +4,15 @@
     angular.module('motech-dashboard')
         .service('AppStateService', stateService);
 
-    stateService.$inject = ['$q', '$rootScope', 'AuthService', 'ServerService'];
-    function stateService ($q, $rootScope, AuthService, ServerService) {
+    stateService.$inject = ['$q', '$rootScope', 'AuthService', 'ServerService', 'i18nService'];
+    function stateService ($q, $rootScope, AuthService, ServerService, i18nService) {
         $rootScope.$on('motech.refresh', refreshReady);
 
         function refreshReady(){
             $q.all({
                 authenticated: AuthService.getCurrentUser(),
-                server: ServerService.whenReady()
+                server: ServerService.whenReady(),
+                i18n: i18nService.getLanguages()
             })
             .then(function(){
                 $rootScope.$broadcast('motech.app.ready');

--- a/src/common/input-map/messages/input-map.en.properties
+++ b/src/common/input-map/messages/input-map.en.properties
@@ -1,0 +1,4 @@
+inputMap.add=123
+inputMap.remove=123
+inputMap.value=123
+inputMap.key=123

--- a/src/i18n/i18n.config.js
+++ b/src/i18n/i18n.config.js
@@ -7,7 +7,7 @@
 
     i18nSetLoader.$inject = ['$translateProvider'];
     function i18nSetLoader ($translateProvider){
-        $translateProvider.useSanitizeValueStrategy('sanitize');
+        $translateProvider.useSanitizeValueStrategy('sanitizeParameters');
         $translateProvider.preferredLanguage('en');
         $translateProvider.useLoader('i18nLoader');
     }

--- a/src/i18n/i18n.form.directive.js
+++ b/src/i18n/i18n.form.directive.js
@@ -4,8 +4,8 @@
     angular.module('motech-server')
         .directive('motechI18nForm', directive);
 
-    controller.$inject = ['$scope', 'i18nService', 'LoadingModal'];
-    function controller($scope, i18nService, LoadingModal){
+    controller.$inject = ['$scope', '$state', 'i18nService', 'LoadingModal'];
+    function controller($scope, $state, i18nService, LoadingModal){
         $scope.languages = i18nService.languages;
 
         LoadingModal.open();

--- a/src/i18n/i18n.loader.js
+++ b/src/i18n/i18n.loader.js
@@ -4,20 +4,37 @@
     angular.module('motech-server')
         .factory('i18nLoader', i18nLoader);
 
-    i18nLoader.$inject = ['$q', '$http', 'ServerService'];
-    function i18nLoader ($q, $http, ServerService) {
+    i18nLoader.$inject = ['$q', '$http', 'ServerService', 'i18nService'];
+    function i18nLoader ($q, $http, ServerService, i18nService) {
 
-        return function(options){
+        function getLang(URL){
             var deferred = $q.defer();
 
-            $http.get(ServerService.formatURL('/module/server/lang/locate'))
+            $http.get(URL)
             .then(function(response){
                 deferred.resolve(response.data);
             })
             .catch(function(){
-                deferred.reject();
-            });
+                deferred.resolve({});
+            });            
 
+            return deferred.promise;
+        }
+
+        return function(){
+            var deferred = $q.defer();
+
+            i18nService.getLanguages()
+            .then(function(){
+                var currentLang = i18nService.getCurrentLanguage();
+                $q.all({
+                    server: getLang(ServerService.formatURL('/module/server/lang/locate')),
+                    local: getLang('i18n-messages/motech-messages.'+currentLang.key+'.json')
+                }).then(function(response){
+                    deferred.resolve(angular.extend(response.server, response.local));
+                });
+            });
+            
             return deferred.promise;
         };
     }

--- a/src/i18n/i18n.modal.js
+++ b/src/i18n/i18n.modal.js
@@ -6,17 +6,20 @@
 
     modal.$inject = ['$rootScope', '$compile', 'i18nService', 'BootstrapDialog'];
     function modal($rootScope, $compile, i18nService, BootstrapDialog){
-        var modal = new BootstrapDialog({
-            message: $compile('<motech-i18n-form></motech-i18n-form>')($rootScope.$new())
-        });
+        var modal = false;
 
         $rootScope.$on('motech.refresh', closeModal);
 
         function openModal (){
+            modal = new BootstrapDialog({
+                message: $compile('<motech-i18n-form></motech-i18n-form>')($rootScope.$new())
+            });
             modal.open();
         }
         function closeModal (){
-            modal.close();
+            if(modal){
+                modal.close();
+            }
         }
 
         return {

--- a/src/i18n/i18n.service.js
+++ b/src/i18n/i18n.service.js
@@ -57,13 +57,9 @@
             $http.post(ServerService.formatURL('/module/server/userlang'),{
                 language: language
             }).then(function(){
-                $translate.use(language)
-                .then(function(){
-                    getLanguages() // update current state from server...
-                    .then(function(){
-                        deferred.resolve();
-                    });
-                });
+                return $translate.use(language); // triggers i18n.loader
+            }).then(function(){
+                deferred.resolve();
             });
             return deferred.promise;
         }

--- a/src/i18n/i18n.service.spec.js
+++ b/src/i18n/i18n.service.spec.js
@@ -1,0 +1,114 @@
+describe('i18n Service', function() {
+  var rootScope, httpBackend, translate, i18nService, serverService;
+
+  beforeEach(module('motech-i18n'));
+  beforeEach(module('motech-templates'));
+
+  beforeEach(inject(function($rootScope, $httpBackend, $translate, _i18nService_, _ServerService_){
+    rootScope = $rootScope;
+    httpBackend = $httpBackend;
+    translate = $translate;
+    i18nService = _i18nService_;
+    serverService = _ServerService_;
+
+    serverService.setReady(true);
+  }));
+
+  beforeEach(function(){
+    httpBackend.when('GET', 'i18n-messages/motech-messages.en.json')
+    .respond({
+      'sample.message': 'Foo',
+      'sample.other': 'Bar'
+    });
+
+    httpBackend.when('GET', serverService.formatURL('/module/server/lang/locate'))
+    .respond({
+      'sample.message': 'Message',
+      'sample.other': 'Other'
+    });
+
+    httpBackend.when('GET', 'i18n-messages/motech-messages.pl.json')
+    .respond(404, '');
+  });
+
+  beforeEach(function(){
+    httpBackend.when('GET', serverService.formatURL('/module/server/lang/list'))
+    .respond({
+      "en":"English",
+      "pl":"Polski"
+    });
+
+    var currentLanguage = "en";
+    httpBackend.when('GET', serverService.formatURL('/module/server/lang'))
+    .respond(function(){
+      return [200, currentLanguage];
+    });
+
+    httpBackend.when('POST', serverService.formatURL('module/server/userlang'))
+    .respond(function(method, url, data){
+      var requestData = JSON.parse(data);
+      if(requestData.language){
+        currentLanguage = requestData.language;
+        return [200, ""];
+      } else {
+        return [500, ""];
+      }
+    });
+  });
+
+  beforeEach(function(){
+    spyOn(i18nService, 'getLanguages').and.callThrough();
+    spyOn(translate, 'use').and.callThrough();
+  });
+
+  it('Can get language configuration from Server', function() {
+    var languages = [];
+
+    expect(i18nService.getCurrentLanguage()).not.toBeTruthy();
+
+    i18nService.getLanguages()
+    .then(function(_languages){
+      languages = _languages;
+    });
+    
+    httpBackend.flush();
+    rootScope.$apply();
+    
+    expect(i18nService.getCurrentLanguage().key).toEqual('en');
+    expect(languages.length).toEqual(2);
+  });
+
+  it('Can set server language configuration', function(){
+    i18nService.setLanguage('pl');
+
+    httpBackend.flush();
+    rootScope.$apply();
+
+    expect(i18nService.getCurrentLanguage().key).toBe("pl");
+    expect(translate.use.calls.any()).toBeTruthy();
+  });
+
+  it('Can have server languages overridden by local languages', function(){
+    expect(i18nService.getMessage("sample.message")).toEqual("sample.message");
+
+    i18nService.setLanguage('en');
+    httpBackend.flush();
+    rootScope.$apply();
+
+    expect(i18nService.getMessage("sample.message")).not.toEqual("sample.message");
+    expect(i18nService.getMessage("sample.message")).not.toEqual("Message");
+    expect(i18nService.getMessage("sample.message")).toEqual("Foo");
+  });
+
+  it('Can fail to load local language, and still load server language', function(){
+    expect(i18nService.getMessage("sample.message")).toEqual("sample.message");
+
+    i18nService.setLanguage('pl');
+    httpBackend.flush();
+    rootScope.$apply();
+
+    expect(i18nService.getMessage("sample.message")).not.toEqual("sample.message");
+    expect(i18nService.getMessage("sample.message")).toEqual("Message");
+  });
+
+});

--- a/src/server/server.service.js
+++ b/src/server/server.service.js
@@ -13,6 +13,7 @@
 
         this.whenReady = whenReady;
         this.isReady = isReady;
+        this.setReady = setReady;
 
         this.formatURL = formatUrl;
         this.isURL = checkServerUrl;
@@ -45,6 +46,10 @@
                 return true;
             }
             return false;
+        }
+
+        function setReady(_ready){
+            ready = _ready;
         }
 
         function whenReady() {


### PR DESCRIPTION
There are a couple of changes in this PR that I'm not super happy with, so I'd love some feedback before this is merged.

Overall this PR allows modules to expose language property files, which are then gathered by gulp and injected into the i18n modules as 'i18nMessages' -- the other commits in this file help prove that this patch works.

## Places I'd like feedback
### (A) [Gulp Task i18n-messages.js](https://github.com/motech/motech-ui/blob/a14fde26be467b3ef2570fb30851c817a352c3f7/gulpfile.js/tasks/i18n-messages.js)
I don't think we really need to build or inject languages directly into the UI. The reason for doing this would be to prevent 'flashes of un-rendered content' when the application is loading.

Since there isn't a fully fleshed out loading page, nor do we directly show un-rendered content, any translation content should be loaded by the time the application starts to render. If we found that there is a load time problem, we could add a hook to the main application loop that would wait until all translation content has loaded.

I will admit though, I think its kinda rad to just render all the i18n messages into the motech.js file.

### (B) [motech-list translating column-headers](https://github.com/motech/motech-ui/commit/7d5565a573d6992b3815fe833962413a668a2a5f)
I initially said that all motech-common level components shouldn't have tranlateable content in them, and that a little impossible. An example is the input-map component that should have language for its own labels and buttons (passing a dictionary of strings would be a little weird)

For the column titles in motech-list, instead of using a translate filter outside of the component to render these strings, I'm passing them as raw attributes that don't get rendered. To compensate, I changed the titles to simply be rendered inside motech-list, and changed the argument that is passed in to a i18n message token.

I feel that it would be more clean to evaluate i18n message tokens as soon as possible, and passing rendered strings to where they will be used — rather than being lazy and rendering the strings at the last possible second.

A contrasting example would be how the auth login modal window is created, where the login form component is rendered using $compile before being passed to the ModalWindow. 