### PR TITLE
Fixed loss of scope in Email Logs Pagination

### DIFF
--- a/src/email/logs.contoller.js
+++ b/src/email/logs.contoller.js
@@ -12,13 +12,13 @@
         $scope.search = {};
         $scope.$watch('search', updateSearch, true);
 
-        $scope.pageChanged = changePage;
+        $scope.changePageTo = changePageTo;
         
         $scope.showExportModal = showExportModal;
         $scope.hideExportModal = hideExportModal;
 
-        function changePage(){
-            EmailLogsService.getPage($scope.currentPage)
+        function changePageTo(page){
+            EmailLogsService.getPage(page)
             .then(updateRows);
         }
 

--- a/src/email/logs.html
+++ b/src/email/logs.html
@@ -18,7 +18,7 @@
         </motech-list-collapsible>
     </motech-list-item>
     <motech-list-footer>
-        <uib-pagination total-items="totalItems" ng-model="currentPage" ng-change="pageChanged()"></uib-pagination>
+        <uib-pagination total-items="totalItems" ng-model="currentPage" ng-change="changePageTo(currentPage)"></uib-pagination>
     </motech-list-footer>
 </motech-list>
 <motech-sidebar title="{{ 'email.logging.filters' | translate }}">


### PR DESCRIPTION
@jredlarski ~

Here are changes that fix pagination not working (it was a loss of scope) // I would like to write a test to make sure this doesn't break again by accident -- but I'm drawing a blank about where that test should live, so unless you have a suggestion, I feel we should just merge this sucker...

After moving pagination into transcluded scope of the footer for motech-list, the ng-change function lost scope to the currentPage variable. To fix this, I changed the function in ng-change to take a page number that exists in the transcluded scope.
