### PR TITLE
MOTECH-2531: Fixes after QA

### DIFF
--- a/src/common/time-picker.directive.js
+++ b/src/common/time-picker.directive.js
@@ -13,9 +13,7 @@
                 if(!isReadOnly) {
                     angular.element(element).timepicker({
                         onSelect: function (timeTex) {
-                            scope.safeApply(function () {
-                                ngModel.$setViewValue(timeTex);
-                            });
+                            ngModel.$setViewValue(timeTex);
                         }
                     });
                 }

--- a/src/scheduler/jobs-service.factory.js
+++ b/src/scheduler/jobs-service.factory.js
@@ -86,7 +86,7 @@
                 listener = scope;
             },
             "setParam": function(fieldName, value) {
-                params[fieldName] = value;
+                params[fieldName] = ((!value || value.length === 0) ? "" : value);
             },
             "setCurrentJob": function(job) {
                 currentJob = job;


### PR DESCRIPTION
When all checkboxes are unselected, http request is send with all necessary params. All jobs display on one page in the same way as on the old Motech UI.
Removed unnecessary method that caused errors in console from time-picker directive.