### PR TITLE
i18n message documentation

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,20 @@
+# i18n and Localized Content
+The MOTECH-UI framework supports i18n and localized content that can be delivered from either the MOTECH Server or locally built into the UI. All content displayed in the UI should be rendered from message strings.
+
+This functionality is mostly supported by the [angular-translate]() framework, and the message-fromat parsing library.
+
+## Message Sources
+There are two ways that translated messages can be loaded into the UI, either from the MOTECH Server, or locally at build time. The content for these strings are refreshed on the 'motech.reload' event.
+
+All messages are written in JAVA's message property format, and then changed into JSON before being loaded into the UI.
+
+### Local MOTECH Message Strings
+Message strings can be loaded locally into the MOTECH-UI by creating a .properties file in any source directory. All files must meet the following file naming pattern:
+
+```
+[name].[language abbreviation].properties
+```
+
+'Name' should reference the UI component that the strings belong to. 'Language abbreviation' must be the two letter abbreviation for the language — this will be used to build separate .json files that are loaded into the MOTECH-UI on demand.
+
+All local message strings overwrite MOTECH Server message strings.


### PR DESCRIPTION
@jredlarski Here is the start of some documentation for local i18n messages.

I'll fill out this documentation over the next day or two — but please let me know what is lacking. 

I will add documentation for the i18n source files — I'm not sure what would be the best method to document the [i18n build script](https://github.com/motech/motech-ui/blob/master/gulpfile.js/tasks/i18n-messages.js), so let me know if you have any thoughts 