### PR TITLE
MOTECH-2824 Wrong definitions CSS classes for buttons when hover element

### DIFF
--- a/src/common/base/base.buttons.scss
+++ b/src/common/base/base.buttons.scss
@@ -20,11 +20,35 @@ markup:
 Styleguide 1.2
 */
 
-button.button,
+button,
 .button,
 .button-default {
     @extend .btn;
     @include button($btn-default-color, $btn-default-bg, $btn-default-border);
+}
+button.btn-default,
+.btn-default {
+    @include button($btn-default-color, $btn-default-bg, $btn-default-border);
+}
+button.btn-primary,
+.btn-primary {
+    @include button($btn-primary-color, $btn-primary-bg, $btn-primary-border);
+}
+button.btn-success,
+.btn-success {
+    @include button($btn-success-color, $btn-success-bg, $btn-success-border);
+}
+button.btn-info,
+.btn-info {
+    @include button($btn-info-color, $btn-info-bg, $btn-info-border);
+}
+button.btn-warning,
+.btn-warning {
+    @include button($btn-warning-color, $btn-warning-bg, $btn-warning-border);
+}
+button.btn-danger,
+.btn-danger {
+    @include button($btn-danger-color, $btn-danger-bg, $btn-danger-border);
 }
 button.primary,
 .button-primary {

--- a/src/common/base/base.buttons.scss
+++ b/src/common/base/base.buttons.scss
@@ -4,7 +4,6 @@ Buttons
 Buttons represent taking an action in MOTECH - juxoposed to a link which represents navigating through MOTECH. Most buttons should be the default color, with the exception of: a primary action button (which submits a form of changes a state), an add button which is creating new data in MOTECH (and should launch a modal window), or a delete button (which much launch a modal window to confirm the action).
 
 markup:
-<button >Button</button>
 <button class="button">Button</button>
 <button class="active">Active Button</button>
 <button class="disabled">Disabled Button</button>
@@ -53,6 +52,10 @@ button.btn-danger,
 button.primary,
 .button-primary {
     @include button($btn-primary-color, $btn-primary-bg, $btn-primary-border);
+}
+button.btn-inverse,
+    .btn-inverse {
+    @include button($btn-default-bg, $btn-default-color, $btn-default-border);
 }
 button.add,
 .button-add,

--- a/src/common/base/base.buttons.scss
+++ b/src/common/base/base.buttons.scss
@@ -5,6 +5,7 @@ Buttons represent taking an action in MOTECH - juxoposed to a link which represe
 
 markup:
 <button >Button</button>
+<button class="button">Button</button>
 <button class="active">Active Button</button>
 <button class="disabled">Disabled Button</button>
 <button class="button-primary">Primary Button</button>
@@ -19,7 +20,7 @@ markup:
 Styleguide 1.2
 */
 
-button,
+button.button,
 .button,
 .button-default {
     @extend .btn;


### PR DESCRIPTION
this '&:hover,' was probably overwriting other hovers with default color - gray, now its just empty 